### PR TITLE
changes to karyotype. Limit string length, collpase adjacent bands, a…

### DIFF
--- a/R/karyotype.R
+++ b/R/karyotype.R
@@ -47,12 +47,14 @@ grl2bedpe = function (
 #' Convert gGraph to karyotype
 #' 
 #' @export
+
 annotate_karyotype = function(
 	gg, 
 	segment_size_threshold = 5e6, 
 	chr_fraction_threshold = 0.9, 
 	arm_fraction_threshold = 0.9, 
-	band_segment_ratio_threshold = 0.1
+	band_segment_ratio_threshold = 0.1,
+        event_count_thresh = 5
 ) {
   cyto = Skilift:::process_cytoband()
   cyto$arm = gsub("^(p|q).*", "\\1", cyto$band)
@@ -95,7 +97,7 @@ annotate_karyotype = function(
 
     grl = S4Vectors::split(breakpoints, breakpoints$grl.ix)
   	bedpe = grl2bedpe(grl, add_breakend_mcol = TRUE, zerobased = FALSE)
-
+    
     isTranslocation = !(bedpe$first.chrom_name == bedpe$second.chrom_name)
     k_type = dplyr::case_when(
       bedpe$first.class == "TRA-like" ~ "t",
@@ -118,6 +120,12 @@ annotate_karyotype = function(
 
     if (any(isBig))
       annotated_tra_inv = glue::glue('{k_type}({k_chrom})({k_bands})')[isBig]
+
+    ## If the length is too big, don't show. Set to 5 for now
+    if(length(annotated_tra_inv) > event_count_thresh){
+      annotated_tra_inv = "multiple tra/inv events"  
+    }
+
   }
 
   segments = gg$nodes$gr
@@ -138,45 +146,71 @@ annotate_karyotype = function(
   annotated_cna = ""
 
   events = segments[
-    segments$cn != 2 
-    ## FIXME: account properly for Y chromosomes
+    width(segments) > segment_size_threshold ## Removing small segs, will collapse eventually
     & seqnames(segments) != "Y"
   ]
 
   if (length(events) > 0) {
-    events$label = ifelse(events$cn > 2, "dup", "del")
-
+    ## Preserving cn for the chromosome level annotations
+    events$label = ifelse(events$cn > 2, paste0("dup_", events$cn),
+                          ifelse(events$cn == 2, paste0("dip_", events$cn),
+                          paste0("del_", events$cn)))
     events_by_label = gUtils::gr_construct_by(events, "label")
     revents_by_label = GenomicRanges::reduce(events_by_label, ignore.strand = TRUE)
     revents = gUtils::gr_deconstruct_by(revents_by_label, by = "label", meta = TRUE)
     revents = revents %*% cyto
-
     revents_dt = gUtils::gr2dt(revents)
-
     revents_dt[, segment_arm_id := .GRP, by = .(query.id, arm)]
-
     revents_dt = data.table::merge.data.table(revents_dt, genome_sl, by = "seqnames")
 
-    chr_stats = revents_dt[, sum(width) / chr_length[1], by = .(seqnames, label)]
+    ## Some maneuvering to get the chromosomes where entire chr
+    ## is gained and more events are overlayed
+    revents_dt[, c("label", "cn") := tstrsplit(label, "_")]
+    revents_dt[, cn := as.numeric(cn)]
+    ## This is to assume a base level CN state for each CHR
+    min_cn_dt = unique(revents_dt[, .(chr_lv_cn = if (all(cn > 2)) min(cn[cn > 2]) else (if (any(cn == 2)) 2 else max(cn))), by = seqnames])
+    revents_dt = merge(revents_dt, min_cn_dt, by = "seqnames", all.x = T)
+    revents_dt[, chr_level_group := paste0(label, "_", chr_lv_cn)]
 
+    ## CHR LEVEL
+    chr_stats = revents_dt[, sum(width) / chr_length[1],
+                           by = .(seqnames, chr_level_group)]
     chr_events = data.table::copy(chr_stats[V1 > chr_fraction_threshold])
-    chr_events[, label := ifelse(label == "dup", "+", "-")]
-    annotated_chr_cna = with(chr_events, glue::glue('{label}{seqnames}'))
+    chr_events = chr_events[!(grepl("dip", chr_level_group))]
 
+    if (nrow(chr_events) > 0){
+        chr_events[, c("label", "cn") := tstrsplit(chr_level_group, "_")]
+        chr_events[, cn := as.numeric(cn)]
+
+    ## This ensures that if there are 2 or more extra copies that gets
+    ## propogated as per the convention
+        chr_events[, suffix := ifelse(grepl("dup", label),
+                                      ifelse(cn > 3, paste0("x", as.numeric(cn)-2), ""), "")]
+        chr_events[, label := ifelse(grepl("dup", label), "+", "-")]
+        annotated_chr_cna = with(chr_events, glue::glue('{label}{seqnames}{suffix}'))
+    } else {
+      annotated_chr_cna = ""
+    }
+
+    ## ARM LEVEL
     revents_arm_dt = data.table::merge.data.table(revents_dt, rcyto_arm_dt[, .(seqnames, arm, arm_width = width)], by = c("seqnames", "arm"))
-    arm_stats = revents_arm_dt[, sum(width) / arm_width[1], by = .(seqnames, label, arm)]
-    arm_events = arm_stats[V1 > arm_fraction_threshold & !seqnames %in% chr_events$seqnames]
-
+    ## No need to exclude events that were in whole chr, since we can now remove segs
+    ## that matched whole chr lvele cn events above
+    if(nrow(chr_events) > 0){
+        revents_arm_dt = revents_arm_dt[cn != chr_lv_cn]
+    }
+    revents_arm_dt = revents_arm_dt[!(grepl("dip", chr_level_group))] 
+    arm_stats = revents_arm_dt[, sum(width) / arm_width[1],
+                                                by = .(seqnames, label, arm)]
+    arm_events = arm_stats[V1 > arm_fraction_threshold]
     annotated_arm_cna = with(arm_events, glue::glue('{label}({seqnames})({arm})'))
 
-    band_events_prefiltered = data.table::copy(revents_dt)
-    band_events_prefiltered = band_events_prefiltered[!seqnames %in% chr_events$seqnames]
-    band_events_prefiltered = band_events_prefiltered[!paste(seqnames, arm) %in% arm_events[, paste(seqnames, arm)]]
+    ## BAND LEVEL
+    ## Same for band level
+    band_events_prefiltered = data.table::copy(revents_arm_dt)
     band_events_prefiltered = band_events_prefiltered[stain != "acen"]
-
     band_events_prefiltered[, band_segment_ratio := sum(width) / band_width[1], by = .(segment_arm_id)]
     band_events_prefiltered[, total_segment_width := sum(width), by = segment_arm_id]
-
     band_events = band_events_prefiltered[total_segment_width > segment_size_threshold & band_segment_ratio >= band_segment_ratio_threshold]
 
     band_events_collapsed = band_events[, .(
@@ -187,23 +221,52 @@ annotate_karyotype = function(
       label = label[1]
     ), by = .(segment_arm_id)]
 
+   ## Additional logic to collapse adjacent bands that have the same copy states 
+   band_events_collapsed[, diff_next := abs(segment_arm_id - shift(segment_arm_id, type = "lag"))]
+   band_events_collapsed[, diff_prev := abs(segment_arm_id - shift(segment_arm_id, type = "lead"))]
+   band_events_collapsed[, diff := min(diff_next, diff_prev, na.rm = T), by = segment_arm_id]
+   band_events_collapsed[, group_adj := paste0(seqnames, "_", arm, "_", label, "_", diff)]
+
+   band_events_collapsed = band_events_collapsed[, .(
+      seqnames = seqnames[1],
+      min_band = min_band[1],
+      max_band = max_band[.N],
+      arm = arm[1],
+      label = label[1]
+    ), by = .(group_adj)]
+
     band_events_collapsed[, first_band := ifelse(arm == "p", max_band, min_band)]
     band_events_collapsed[, last_band := ifelse(arm == "p", min_band, max_band)]
+    
+    ## Filtering out arm level events
+    if(nrow(arm_events) > 0){
+      arm_events[, long_label := paste0(seqnames, "_", label, "_", arm)]
+      band_events_collapsed[, long_label := paste0(seqnames, "_", label, "_", arm)]
+      band_events_collapsed = band_events_collapsed[!long_label %in% arm_events$long_label]
+    }
 
     annotated_band_cna = with(band_events_collapsed, {
       glue::glue('{label}({seqnames})({first_band},{last_band})')
     })
 
+    ## If the length is too big, don't show. Set to 5 for now
+    if(length(annotated_band_cna) > event_count_thresh){
+      annotated_band_cna = "multiple band events"  
+    }
   }
   
   karyotype_string = paste(c(
-    annotated_tra_inv,
     annotated_chr_cna,
+    annotated_tra_inv,
     annotated_arm_cna,
     annotated_band_cna
   ), collapse = ",")
 
+  karyotype_string = gsub(",,", ",", karyotype_string)
   karyotype_string = gsub("^,|,$", "", karyotype_string)
+  
   
   return(karyotype_string)
 }
+
+


### PR DESCRIPTION
…dd number of copies to whole chr changes, etc.

**Description:**

- Patches to Karyotype string. 

**Changes:**

- String length is limited to 5 events per event type for INV/TRA and band level events
- Adjacent bands with same status are collapsed
- Number of CHR copies above 2 are highlighted for CHR level events
- Overlapping CHR and smaller events are categorized separately

